### PR TITLE
Udpate theme to 4.2.0

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -13,16 +13,16 @@ permissions:
 
 jobs:
   build:
-    # TODO: here and bellow do we use LST or latest version?
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 1
+          #ref: ${{ github.event.inputs.branch }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.127.0
+        uses: ruby/setup-ruby@v1.204.0
         with:
           ruby-version: '3.1'
           bundler-cache: true
@@ -30,7 +30,18 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
+
+      - name: Set Jekyll environment
+        id: name
+        run: |
+          if [ "$REPO_OWNER" == "UHasselt-BiomedicalDataSciences" ]; then
+            echo "jekyll_env=production" >> $GITHUB_OUTPUT
+          else
+            echo "jekyll_env=development" >> $GITHUB_OUTPUT
+          fi
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
 
       - name: Install dependencies
         run: |
@@ -42,21 +53,23 @@ jobs:
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           PAGES_REPO_NWO: ${{ github.repository }}
+          JEKYLL_BUILD_BRANCH: ${{ github.ref_name }}
           JEKYLL_ENV: ${{ steps.name.outputs.jekyll_env }}
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JEKYLL_BUILD_BRANCH: ${{ github.ref_name }}
           JEKYLL_BASE_PATH: ${{ steps.pages.outputs.base_path }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
+
 
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
 
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.event.repository.default_branch == github.ref_name)
+
     concurrency:
       group: "pages"
       cancel-in-progress: true
@@ -64,8 +77,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -68,7 +68,13 @@ jobs:
 
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.event.repository.default_branch == github.ref_name)
+      (
+        github.event_name == 'push' &&
+        (
+          github.repository_owner != 'UHasselt-BiomedicalDataSciences' ||
+          github.event.repository.default_branch == github.ref_name
+        )
+      )
 
     concurrency:
       group: "pages"

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,16 @@
 source "https://rubygems.org"
 
-gem "elixir-toolkit-theme-plugins", "~> 0.1.9"
-gem "webrick", "~> 1.7"
-gem "jekyll", "~> 4.3.2"
+gem "elixir-toolkit-theme-plugins", "~> 0.1.10"
+gem "webrick", "~> 1.9.1"
+gem "jekyll", "~> 4.4.1"
 gem "jemoji", "~> 0.13.0"
 gem "kramdown-parser-gfm", "~> 1.1"
 gem 'jekyll-octicons'
+gem "csv", "~> 3.3.5" # This is required when using ruby >= 3.3
 
+# Hack: fix the version so no deprecation warnings are emited.
+#       We have to wait until tollkit theme bumps up bootstrap version
+gem "sass-embedded", "~> 1.63.6"
 
 group :jekyll_plugins do
   gem "jekyll-redirect-from", "~> 0.16.0"

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ install:
 dev:
 	JEKYLL_BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	JEKYLL_ENV=development \
-	bundle exec jekyll serve --livereload --incremental
-
+	bundle exec jekyll serve --livereload --incremental --trace
 .PHONY: build
 build:
 	JEKYLL_ENV=production bundle exec jekyll build

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ COC_EMAIL: lotte.geys@uhasselt.be
 RDM_KIT_REPO: https://github.com/elixir-europe/rdmkit
 RDM_KIT_WEBSITE: https://rdmkit.elixir-europe.org
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@3.2.0
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@4.2.0
 
 sass:
   style: compressed


### PR DESCRIPTION
- Update elixir theme to 4.2.0
- fix deployment issues
- Update dependencies. Get rid of sass deprecation warnings by pinning a lower version.
   We have to wait until elixir toolkit theme updates bootstrap then we can remove this `sass-embedded` pinned version
- "make dev" now uses --trace for easier debugging
- allow arbitrary branch deployment on forked repositories.
  This way we can inspect how it looks  https://gvinterhalter.github.io/federated-learning-toolkit/WiNGS
  **A caveat is that multiple branches on single fork will override each others deployment**